### PR TITLE
Further cleanup

### DIFF
--- a/de.persosim.simulator.test/META-INF/MANIFEST.MF
+++ b/de.persosim.simulator.test/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PersoSim Simulator Test
 Bundle-SymbolicName: de.persosim.simulator.test
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: HJP Consulting GmbH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: de.persosim.simulator;bundle-version="1.0.0"
+Require-Bundle: de.persosim.simulator;bundle-version="[0.1.0,1.0.0)"
 Export-Package: de.persosim.simulator.protocols,
  de.persosim.simulator.test,
  de.persosim.simulator.test.globaltester,

--- a/de.persosim.simulator.test/src/de/persosim/simulator/protocols/TR03110Test.java
+++ b/de.persosim.simulator.test/src/de/persosim/simulator/protocols/TR03110Test.java
@@ -125,7 +125,7 @@ public class TR03110Test extends PersoSimTestCase {
 	@Test
 	public void testParsePublicKeyEcUsingTrustPointKey() throws Exception {
 		//call mut
-		assertArrayEquals(publicKeyEc.getEncoded(), TR03110.parsePublicKey(publicKeyDataEcNoDomainParameters, publicKeyEc).getEncoded());
+		assertArrayEquals(publicKeyEc.getEncoded(), TR03110.parseCertificatePublicKey(publicKeyDataEcNoDomainParameters, publicKeyEc).getEncoded());
 	}
 	
 	/**
@@ -137,7 +137,7 @@ public class TR03110Test extends PersoSimTestCase {
 	@Test
 	public void testParsePublicKeyEcNoTrustPointKey() throws Exception {
 		//call mut
-		assertArrayEquals(publicKeyEc.getEncoded(), TR03110.parsePublicKey(publicKeyDataEc, null).getEncoded());
+		assertArrayEquals(publicKeyEc.getEncoded(), TR03110.parseCertificatePublicKey(publicKeyDataEc, null).getEncoded());
 	}
 	
 	/**

--- a/de.persosim.simulator.test/src/de/persosim/simulator/protocols/pace/AbstractPaceProtocolTest.java
+++ b/de.persosim.simulator.test/src/de/persosim/simulator/protocols/pace/AbstractPaceProtocolTest.java
@@ -32,7 +32,6 @@ import de.persosim.simulator.cardobjects.TrustPointIdentifier;
 import de.persosim.simulator.crypto.DomainParameterSet;
 import de.persosim.simulator.crypto.StandardizedDomainParameters;
 import de.persosim.simulator.crypto.certificates.CardVerifiableCertificate;
-import de.persosim.simulator.crypto.certificates.PublicKeyReference;
 import de.persosim.simulator.exception.CarParameterInvalidException;
 import de.persosim.simulator.exception.CertificateNotParseableException;
 import de.persosim.simulator.platform.CardStateAccessor;
@@ -171,7 +170,7 @@ public class AbstractPaceProtocolTest extends PersoSimTestCase {
 	@Test
 	public void testSetAtWithChat() throws CarParameterInvalidException, InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException, GSSException, CertificateNotParseableException{
 		// prepare the mock
-		final TrustPointCardObject trustpoint = new TrustPointCardObject(new TrustPointIdentifier(TerminalType.IS), new PublicKeyReference(cvcaIsCarTlv), new CardVerifiableCertificate(cvcaIsTlv)); 
+		final TrustPointCardObject trustpoint = new TrustPointCardObject(new TrustPointIdentifier(TerminalType.IS), new CardVerifiableCertificate(cvcaIsTlv)); 
 		
 		new NonStrictExpectations() {
 			{

--- a/de.persosim.simulator.test/src/de/persosim/simulator/protocols/ta/AbstractTaProtocolTest.java
+++ b/de.persosim.simulator.test/src/de/persosim/simulator/protocols/ta/AbstractTaProtocolTest.java
@@ -98,7 +98,7 @@ public class AbstractTaProtocolTest extends PersoSimTestCase {
 
 		chr = new PublicKeyReference("DE", "JUNIT", "00000");
 
-		trustPoint = new TrustPointCardObject(null, chr, issuingCertificate);
+		trustPoint = new TrustPointCardObject(null, issuingCertificate);
 	}
 
 	/**
@@ -178,8 +178,6 @@ public class AbstractTaProtocolTest extends PersoSimTestCase {
 
 		assertEquals(Deencapsulation.getField(taProtocol,
 				"mostRecentTemporaryCertificate"), certificate);
-		assertEquals(Deencapsulation.getField(taProtocol,
-				"mostRecentTemporaryPublicKeyReference"), chr);
 	}
 
 	/**

--- a/de.persosim.simulator/META-INF/MANIFEST.MF
+++ b/de.persosim.simulator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PersoSim
 Bundle-SymbolicName: de.persosim.simulator
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: HJP Consulting GmbH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: de.persosim.simulator,

--- a/de.persosim.simulator/src/de/persosim/simulator/cardobjects/ObjectStore.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/cardobjects/ObjectStore.java
@@ -225,14 +225,13 @@ public class ObjectStore {
 	}
 
 	/**
-	 * Search for the first dedicated file parent of a given {@link CardObject}.
+	 * Search for the first dedicated file parent of a given {@link CardObject}
+	 * if it is not itself a {@link DedicatedFile}.
 	 * 
-	 * FIXME MBK method violates documentation
-	 * This method is to return "the first matching parent, _excluding_ the starting object itself".
-	 * If I start at MF why do I get MF in return if the starting object is to be excluded?
-	 * 
-	 * @param {@link CardObject} to start the search with
-	 * @return the first matching parent, excluding the starting object itself
+	 * @param currentObject
+	 *            {@link CardObject} to start the search with
+	 * @return the first matching parent, or the given object, if it is a
+	 *         {@link DedicatedFile}
 	 */
 	private DedicatedFile findFirstParentDedicatedFile(CardObject currentObject) {
 		while (!(currentObject instanceof DedicatedFile)) {

--- a/de.persosim.simulator/src/de/persosim/simulator/cardobjects/TrustPointCardObject.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/cardobjects/TrustPointCardObject.java
@@ -21,12 +21,6 @@ import de.persosim.simulator.exception.CertificateUpdateException;
 @XmlRootElement
 public class TrustPointCardObject extends AbstractCardObject {
 	
-	//FIXME MBK why are the publicKeyReferences duplicated here? They are accessible through the certificates
-	@XmlElement
-	PublicKeyReference currentPublicKeyReference;
-	@XmlElement
-	PublicKeyReference previousPublicKeyReference;
-	
 	@XmlElement
 	CardVerifiableCertificate currentCertificate;
 	@XmlElement
@@ -40,11 +34,9 @@ public class TrustPointCardObject extends AbstractCardObject {
 	}
 
 	public TrustPointCardObject(TrustPointIdentifier identifier,
-			PublicKeyReference currentReference,
 			CardVerifiableCertificate currentCertificate) {
 		this.identifier = identifier;
 		this.currentCertificate = currentCertificate;
-		this.currentPublicKeyReference = currentReference;
 	}
 
 	@Override
@@ -55,26 +47,10 @@ public class TrustPointCardObject extends AbstractCardObject {
 	}
 
 	/**
-	 * @return the reference, that binds a holder to this trustpoints current
-	 *         certificate
-	 */
-	public PublicKeyReference getCurrentPublicKeyReference() {
-		return currentPublicKeyReference;
-	}
-
-	/**
 	 * @return the current certificate that defines this trustpoint
 	 */
 	public CardVerifiableCertificate getCurrentCertificate() {
 		return currentCertificate;
-	}
-
-	/**
-	 * @return the reference, that binds a holder to this trustpoints previous
-	 *         certificate
-	 */
-	public PublicKeyReference getPreviousPublicKeyReference() {
-		return previousPublicKeyReference;
 	}
 
 	/**
@@ -85,13 +61,15 @@ public class TrustPointCardObject extends AbstractCardObject {
 	}
 
 	/**
-	 * Update the trustpoint using a new certificate.
-	 * 
-	 * XXX MBK add documentation
+	 * Update the trustpoint using a new certificate. This method moves the
+	 * current certificate to the previous position and sets the given input as
+	 * the new current certificate. Due to the certificate scheduling described
+	 * in TR-03110 v2.10 Part 3 2.4 holding two certificates provides for
+	 * seamless certificate roll-over.
 	 * 
 	 * @param newReference
 	 * @param newCertificate
-	 * @throws CertificateUpdateException 
+	 * @throws CertificateUpdateException
 	 */
 	public void updateTrustpoint(PublicKeyReference newReference,
 			CardVerifiableCertificate newCertificate) throws CertificateUpdateException {
@@ -103,9 +81,7 @@ public class TrustPointCardObject extends AbstractCardObject {
 		//}
 		
 		previousCertificate = currentCertificate;
-		previousPublicKeyReference = currentPublicKeyReference;
 		currentCertificate = newCertificate;
-		currentPublicKeyReference = newReference;
 	}
 
 }

--- a/de.persosim.simulator/src/de/persosim/simulator/crypto/certificates/CardVerifiableCertificate.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/crypto/certificates/CardVerifiableCertificate.java
@@ -1,9 +1,7 @@
 package de.persosim.simulator.crypto.certificates;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
+import java.security.GeneralSecurityException;
 import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -100,12 +98,12 @@ public class CardVerifiableCertificate {
 		//public key
 		try {
 			ConstructedTlvDataObject publicKeyData = (ConstructedTlvDataObject) certificateBodyData.getTagField(TR03110.TAG_7F49);
-			publicKeyOid = TR03110.getOidFromPublicKey(publicKeyData);
-			publicKey = TR03110.parsePublicKey(publicKeyData, currentPublicKey);
+			publicKeyOid = new TaOid(publicKeyData.getTagField(TR03110.TAG_06).getValueField());
+			publicKey = TR03110.parseCertificatePublicKey(publicKeyData, currentPublicKey);
 			if (publicKey == null){
 				throw new CertificateNotParseableException("The public key data could not be parsed");
 			}
-		} catch (InvalidKeySpecException | NoSuchAlgorithmException | NoSuchProviderException e) {
+		} catch (GeneralSecurityException e) {
 			throw new CertificateNotParseableException("The public key data could not be parsed");
 		}
 		//certificate holder reference

--- a/de.persosim.simulator/src/de/persosim/simulator/crypto/certificates/CertificateExtension.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/crypto/certificates/CertificateExtension.java
@@ -19,7 +19,7 @@ public class CertificateExtension {
 	TlvDataObjectContainer dataObjects;
 
 	public CertificateExtension(ConstructedTlvDataObject extensionData) {
-		objectIdentifier = TR03110.getOidFromPublicKey(extensionData);
+		objectIdentifier = new TaOid(extensionData.getTagField(TR03110.TAG_06).getValueField());
 		dataObjects = new TlvDataObjectContainer();
 		boolean firstIgnored = false;
 		for (TlvDataObject object : extensionData.getTlvDataObjectContainer()){

--- a/de.persosim.simulator/src/de/persosim/simulator/perso/DefaultPersonalization.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/perso/DefaultPersonalization.java
@@ -44,8 +44,6 @@ import de.persosim.simulator.cardobjects.TrustPointIdentifier;
 import de.persosim.simulator.crypto.DomainParameterSet;
 import de.persosim.simulator.crypto.StandardizedDomainParameters;
 import de.persosim.simulator.crypto.certificates.CardVerifiableCertificate;
-import de.persosim.simulator.crypto.certificates.PublicKeyReference;
-import de.persosim.simulator.exception.CarParameterInvalidException;
 import de.persosim.simulator.exception.CertificateNotParseableException;
 import de.persosim.simulator.protocols.Protocol;
 import de.persosim.simulator.protocols.TR03110;
@@ -276,24 +274,21 @@ public class DefaultPersonalization implements Personalization, Pace {
 			TlvDataObject cvcaIsTlv = ((ConstructedTlvDataObject)new TlvDataObjectContainer(cvcaIsData).getTagField(TR03110.TAG_7F21)).getTagField(TR03110.TAG_7F4E);
 			TlvDataObject cvcaAtTlv = ((ConstructedTlvDataObject)new TlvDataObjectContainer(cvcaAtData).getTagField(TR03110.TAG_7F21)).getTagField(TR03110.TAG_7F4E);
 			TlvDataObject cvcaStTlv = ((ConstructedTlvDataObject)new TlvDataObjectContainer(cvcaStData).getTagField(TR03110.TAG_7F21)).getTagField(TR03110.TAG_7F4E);
-			TlvDataObject cvcaIsChrTlv = ((ConstructedTlvDataObject)((ConstructedTlvDataObject)new TlvDataObjectContainer(cvcaIsData).getTagField(TR03110.TAG_7F21)).getTagField(TR03110.TAG_7F4E)).getTagField(TR03110.TAG_5F20);
-			TlvDataObject cvcaAtChrTlv = ((ConstructedTlvDataObject)((ConstructedTlvDataObject)new TlvDataObjectContainer(cvcaAtData).getTagField(TR03110.TAG_7F21)).getTagField(TR03110.TAG_7F4E)).getTagField(TR03110.TAG_5F20);
-			TlvDataObject cvcaStChrTlv = ((ConstructedTlvDataObject)((ConstructedTlvDataObject)new TlvDataObjectContainer(cvcaStData).getTagField(TR03110.TAG_7F21)).getTagField(TR03110.TAG_7F4E)).getTagField(TR03110.TAG_5F20);
 			
 			//TA trustpoints
 			TrustPointCardObject trustPointIs = new TrustPointCardObject(
 					new TrustPointIdentifier(TerminalType.IS),
-					new PublicKeyReference(cvcaIsChrTlv), new CardVerifiableCertificate((ConstructedTlvDataObject) cvcaIsTlv));
+					new CardVerifiableCertificate((ConstructedTlvDataObject) cvcaIsTlv));
 			mf.addChild(trustPointIs);
 
 			TrustPointCardObject trustPointAt = new TrustPointCardObject(
 					new TrustPointIdentifier(TerminalType.AT),
-					new PublicKeyReference(cvcaAtChrTlv), new CardVerifiableCertificate((ConstructedTlvDataObject) cvcaAtTlv));
+					new CardVerifiableCertificate((ConstructedTlvDataObject) cvcaAtTlv));
 			mf.addChild(trustPointAt);
 
 			TrustPointCardObject trustPointSt = new TrustPointCardObject(
 					new TrustPointIdentifier(TerminalType.ST),
-					new PublicKeyReference(cvcaStChrTlv), new CardVerifiableCertificate((ConstructedTlvDataObject) cvcaStTlv));
+					new CardVerifiableCertificate((ConstructedTlvDataObject) cvcaStTlv));
 			mf.addChild(trustPointSt);
 			
 			//Time store
@@ -549,7 +544,7 @@ public class DefaultPersonalization implements Personalization, Pace {
 			return mf;
 			
 			
-		} catch ( CarParameterInvalidException | CertificateNotParseableException | NoSuchAlgorithmException | NoSuchProviderException | IOException e) {
+		} catch ( CertificateNotParseableException | NoSuchAlgorithmException | NoSuchProviderException | IOException e) {
 			// don't care for the moment
 			e.printStackTrace();
 		}

--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/pace/AbstractPaceProtocol.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/pace/AbstractPaceProtocol.java
@@ -601,15 +601,23 @@ public abstract class AbstractPaceProtocol extends AbstractProtocolStateMachine 
 			
 			//add CARs to response data if available
 			if (trustPoint != null) {
-				if (trustPoint.getCurrentPublicKeyReference() instanceof PublicKeyReference) {
-					constructed7C.addTlvDataObject(new PrimitiveTlvDataObject(
-							TAG_87, trustPoint.getCurrentPublicKeyReference().getBytes()));
-					if (trustPoint.getPreviousPublicKeyReference() instanceof PublicKeyReference) {
+				if (trustPoint.getCurrentCertificate() != null
+						&& trustPoint.getCurrentCertificate()
+								.getCertificateHolderReference() instanceof PublicKeyReference) {
+					constructed7C
+							.addTlvDataObject(new PrimitiveTlvDataObject(
+									TAG_87, trustPoint.getCurrentCertificate()
+											.getCertificateHolderReference()
+											.getBytes()));
+					if (trustPoint.getPreviousCertificate() != null
+							&& trustPoint.getPreviousCertificate()
+									.getCertificateHolderReference() instanceof PublicKeyReference) {
 						constructed7C
 								.addTlvDataObject(new PrimitiveTlvDataObject(
 										TAG_88,
 										trustPoint
-												.getPreviousPublicKeyReference()
+												.getPreviousCertificate()
+												.getCertificateHolderReference()
 												.getBytes()));
 					}
 				}

--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/ri/RiOid.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/ri/RiOid.java
@@ -152,7 +152,7 @@ public class RiOid extends Oid implements Ri, TlvConstants {
 	public PublicKey parsePublicKey(ConstructedTlvDataObject publicKeyData)
 			throws GeneralSecurityException {
 		if (getIdString().contains("ECDH")) {
-			return CryptoUtil.parsePublicKeyEc(publicKeyData);
+			return CryptoUtil.parsePublicKeyEc(publicKeyData, CryptoUtil.parseParameterSpecEc(publicKeyData));
 		}
 		return null;
 	}

--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/ri/RiProtocol.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/ri/RiProtocol.java
@@ -244,7 +244,10 @@ public class RiProtocol implements Protocol, Iso7816, ApduSpecificationIf,
 				}
 
 				if (staticKeyPair == null){
-					// XXX MBK throw a 4Axx statusword when implemented
+					// create and propagate response APDU
+					ResponseApdu resp = new ResponseApdu(PlatformUtil.SW_4A80_WRONG_DATA);
+					processingData.updateResponseAPDU(this,
+							"The static key pair was not set correctly, probably because of missing setAT execution", resp);
 					return;
 				}
 				

--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/ta/TaOid.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/ta/TaOid.java
@@ -2,6 +2,9 @@ package de.persosim.simulator.protocols.ta;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Signature;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -10,6 +13,7 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import de.persosim.simulator.crypto.Crypto;
 import de.persosim.simulator.protocols.Oid;
 import de.persosim.simulator.utils.HexString;
 import de.persosim.simulator.utils.Utils;
@@ -148,6 +152,43 @@ public class TaOid extends Oid {
 			return "SHA-512";
 		}
 		throw new IllegalArgumentException("unknown or invalid algorithm");
+	}
+
+
+
+	/**
+	 * This method finds a signature object fitting this Oid as defined in
+	 * TR-03110 v2.10.
+	 * 
+	 * @return an instance of a {@link Signature} object
+	 * @throws NoSuchAlgorithmException
+	 * @throws NoSuchProviderException
+	 */	
+	public Signature getSignature() throws NoSuchAlgorithmException, NoSuchProviderException {
+		if (equals(TaOid.id_TA_RSA_v1_5_SHA_1)){
+			return Signature.getInstance("SHA1withRSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_RSA_v1_5_SHA_256)){
+			return Signature.getInstance("SHA256withRSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_RSA_v1_5_SHA_512)){
+			return Signature.getInstance("SHA512withRSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_RSA_PSS_SHA_1)){
+			return Signature.getInstance("SHA1withRSA/PSS", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_RSA_PSS_SHA_256)){
+			return Signature.getInstance("SHA256withRSA/PSS", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_RSA_PSS_SHA_512)){
+			return Signature.getInstance("SHA512withRSA/PSS", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_ECDSA_SHA_1)){
+			return Signature.getInstance("SHA1withECDSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_ECDSA_SHA_224)){
+			return Signature.getInstance("SHA224withECDSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_ECDSA_SHA_256)){
+			return Signature.getInstance("SHA256withECDSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_ECDSA_SHA_384)){
+			return Signature.getInstance("SHA384withECDSA", Crypto.getCryptoProvider());
+		} else if (equals(TaOid.id_TA_ECDSA_SHA_512)){
+			return Signature.getInstance("SHA512withECDSA", Crypto.getCryptoProvider());
+		}
+		return null;
 	}
 	
 }

--- a/de.persosim.simulator/src/de/persosim/simulator/tlv/TlvConstants.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/tlv/TlvConstants.java
@@ -7,9 +7,12 @@ package de.persosim.simulator.tlv;
  *
  */
 public interface TlvConstants {
-	
 	public static final TlvTag TAG_06 = new TlvTag((byte) 0x06);
+	public static final TlvTag TAG_42 = new TlvTag((byte) 0x42);
 	public static final TlvTag TAG_53 = new TlvTag((byte) 0x53);
+	public static final TlvTag TAG_65 = new TlvTag((byte) 0x65);
+	public static final TlvTag TAG_67 = new TlvTag((byte) 0x67);
+	public static final TlvTag TAG_73 = new TlvTag((byte) 0x73);
 	public static final TlvTag TAG_7C = new TlvTag((byte) 0x7C);
 	public static final TlvTag TAG_80 = new TlvTag((byte) 0x80);
 	public static final TlvTag TAG_81 = new TlvTag((byte) 0x81);
@@ -20,8 +23,16 @@ public interface TlvConstants {
 	public static final TlvTag TAG_86 = new TlvTag((byte) 0x86);
 	public static final TlvTag TAG_87 = new TlvTag((byte) 0x87);
 	public static final TlvTag TAG_88 = new TlvTag((byte) 0x88);
-	public static final TlvTag TAG_7F4C = new TlvTag((short) 0x7F4C);
-	public static final TlvTag TAG_7F49 = new TlvTag((short) 0x7F49);
+	public static final TlvTag TAG_91 = new TlvTag((byte) 0x91);
+	public static final TlvTag TAG_5F20 = new TlvTag(new byte []{0x5F, 0x20});
+	public static final TlvTag TAG_5F24 = new TlvTag(new byte []{0x5F, 0x24});
+	public static final TlvTag TAG_5F25 = new TlvTag(new byte []{0x5F, 0x25});
+	public static final TlvTag TAG_5F29 = new TlvTag(new byte []{0x5F, 0x29});
+	public static final TlvTag TAG_5F37 = new TlvTag(new byte []{0x5F, 0x37});
+	public static final TlvTag TAG_7F21 = new TlvTag(new byte []{0x7F, 0x21});
+	public static final TlvTag TAG_7F49 = new TlvTag(new byte []{0x7F, 0x49});
+	public static final TlvTag TAG_7F4C = new TlvTag(new byte []{0x7F, 0x4C});
+	public static final TlvTag TAG_7F4E = new TlvTag(new byte []{0x7F, 0x4E});
 
 	public static final TlvValuePlain DER_BOOLEAN_TRUE = new TlvValuePlain(new byte [] {(byte) 0xFF});
 	public static final TlvValuePlain DER_BOOLEAN_FALSE = new TlvValuePlain(new byte [] {0});


### PR DESCRIPTION
- remove BC dependency and rely on java.security objects
- remove obsolete redundant data
- cleanup documentation
- reduce version to 0.1.0 in order to comply with semantic versioning
