### PR TITLE
DefaultPaceProtocol: Reorder tags for MSE:SET AT

### DIFF
--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/pace/DefaultPaceProtocol.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/pace/DefaultPaceProtocol.java
@@ -486,12 +486,12 @@ public class DefaultPaceProtocol extends AbstractPaceProtocol
 						apduSpecification.addTag(tagSpecification);
 						createNewTagSpecification(TAG_83);
 						apduSpecification.addTag(tagSpecification);
+						createNewTagSpecification(TAG_84);
+						tagSpecification.setRequired(REQ_OPTIONAL);
+						apduSpecification.addTag(tagSpecification);
 						createNewTagSpecification(TAG_7F4C);
 						tagSpecification.setRequired(REQ_OPTIONAL);
 						tagSpecification.setAllowUnspecifiedSubTags(true);
-						apduSpecification.addTag(tagSpecification);
-						createNewTagSpecification(TAG_84);
-						tagSpecification.setRequired(REQ_OPTIONAL);
 						apduSpecification.addTag(tagSpecification);
 						apduSpecification.setInitialApdu();
 						registerApduSpecification(apduSpecification);


### PR DESCRIPTION
Not sure if an order is required here at all, but at least TR-03110-3
section B.11.1. MSE:Set AT lists tags 84 and 7f4c in different order.
Gets AutentApp2 a bit further in the authentication process.
