### PR TITLE
Add RiPublicKeyInfo based on dynamic data extracted from RiKeys

### DIFF
--- a/de.persosim.simulator.test/gtTests/de/persosim/simulator/test/globaltester/perso/GtDebugPersoTest.java
+++ b/de.persosim.simulator.test/gtTests/de/persosim/simulator/test/globaltester/perso/GtDebugPersoTest.java
@@ -31,7 +31,7 @@ public class GtDebugPersoTest extends GtDefaultPersoTest {
 		
 //		retVal.add(new GtSuiteDescriptor(GtConstants.PROJECT_EPA_EAC2_BSI, "EAC2_ISO7816_H_01"));
 //		retVal.add(new GtSuiteDescriptor(GtConstants.PROJECT_EPA_EAC2_BSI, "EAC2_ISO7816_K_01"));
-		retVal.add(new GtSuiteDescriptor(GtConstants.PROJECT_EPA_EAC2_BSI, "EAC2_ISO7816_I_01"));
+		retVal.add(new GtSuiteDescriptor(GtConstants.PROJECT_EPA_EAC2_BSI, "EAC2_ISO7816_R_01"));
 //		retVal.add(GtConstants.SUITE_EAC2_ISO7816_P);
 
 		return retVal;

--- a/de.persosim.simulator/src/de/persosim/simulator/perso/DefaultPersonalization.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/perso/DefaultPersonalization.java
@@ -250,7 +250,7 @@ public abstract class DefaultPersonalization extends XmlPersonalization {
 		keyPair = new KeyPair(publicKey, privateKey);
 
 		KeyObject riKey = new KeyObject(keyPair, new KeyIdentifier(1));
-		riKey.addOidIdentifier(new OidIdentifier(new RiOid(Ri.id_RI_ECDH)));
+		riKey.addOidIdentifier(new OidIdentifier(new RiOid(Ri.id_RI_ECDH_SHA_256)));
 		mf.addChild(riKey);
 	}
 

--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/ca/AbstractCaProtocol.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/ca/AbstractCaProtocol.java
@@ -363,7 +363,7 @@ public abstract class AbstractCaProtocol extends AbstractProtocolStateMachine im
 					break;
 				}
 			}
-			if (keyId == -1) continue;
+			if (keyId == -1) continue; // skip keys that dont't provide a keyId
 			
 			//cached values
 			byte[] genericCaOidBytes = null;

--- a/de.persosim.simulator/src/de/persosim/simulator/tlv/Asn1.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/tlv/Asn1.java
@@ -57,6 +57,7 @@ public interface Asn1 {
 	public static final byte UNIVERSAL_BMP_STRING = 0x1E;
 
 	// Tags frequently used within PersoSim (this list should be extended when needed)
+	public static final byte BOOLEAN = UNIVERSAL_BOOLEAN;
 	public static final byte INTEGER = UNIVERSAL_INTEGER;
 	public static final byte BIT_STRING = UNIVERSAL_BIT_STRING;
 	public static final byte OCTET_STRING = UNIVERSAL_OCTET_STRING;

--- a/de.persosim.simulator/src/de/persosim/simulator/tlv/TlvConstants.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/tlv/TlvConstants.java
@@ -35,6 +35,7 @@ public interface TlvConstants {
 	public static final TlvTag TAG_7F4C = new TlvTag(new byte []{0x7F, 0x4C});
 	public static final TlvTag TAG_7F4E = new TlvTag(new byte []{0x7F, 0x4E});
 
+	public static final TlvTag TAG_BOOLEAN = new TlvTag(Asn1.BOOLEAN);
 	public static final TlvTag TAG_INTEGER = new TlvTag(Asn1.INTEGER);
 	public static final TlvTag TAG_BIT_STRING = new TlvTag(Asn1.BIT_STRING);
 	public static final TlvTag TAG_OCTET_STRING = new TlvTag(Asn1.OCTET_STRING);


### PR DESCRIPTION
This requires some definintion of constants wihtin the TlvConstants,
Asn1 and TR03110.
Also the personalized RiOid-Identifer for Ri keys now use specifc
RiKeys.
