### PR TITLE
Allow arbitrary tag order in APDUs

### DIFF
--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/AbstractProtocolStateMachine.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/AbstractProtocolStateMachine.java
@@ -193,6 +193,7 @@ public abstract class AbstractProtocolStateMachine extends AbstractStateMachine 
 	
 	public void createNewTagSpecification(TlvTag tag) {
 		this.tagSpecification = new TlvSpecification(tag);
+		this.tagSpecification.setStrictOrder(STRICT_ORDER);
 	}
 	
 	public void createNewPath() {


### PR DESCRIPTION
According to TR-03110-3 Version 2.20 beta2 section B.14. APDU
Specification: "The receiver SHOULD be capabale [sic] to process APDUs
with data objects given in any order."
