### PR TITLE
Allow arbitrary tag order in APDUs

### DIFF
--- a/de.persosim.simulator/src/de/persosim/simulator/protocols/AbstractProtocolStateMachine.java
+++ b/de.persosim.simulator/src/de/persosim/simulator/protocols/AbstractProtocolStateMachine.java
@@ -189,6 +189,7 @@ public abstract class AbstractProtocolStateMachine extends AbstractStateMachine 
 		
 	public void createNewApduSpecification(String id) {
 		this.apduSpecification = new ApduSpecification(id);
+		apduSpecification.getTags().setStrictOrder(ARBITRARY_ORDER);
 	}
 	
 	public void createNewTagSpecification(TlvTag tag) {


### PR DESCRIPTION
According to TR-03110-3 Version 2.20 beta2 section B.14. APDU
Specification: "The receiver SHOULD be capabale [sic] to process APDUs
with data objects given in any order."
