### PR TITLE
Allow waiting for the server mode

### DIFF
--- a/de.persosim.simulator.test/gtTests/de/persosim/simulator/test/globaltester/GlobalTesterTest.java
+++ b/de.persosim.simulator.test/gtTests/de/persosim/simulator/test/globaltester/GlobalTesterTest.java
@@ -42,6 +42,9 @@ public abstract class GlobalTesterTest implements InfoSource, Iso7816, Tr03110 {
 //	private static final String PATH_LOGGING = BASE_PATH + "\\logging";
 
 	protected static GtServerConnection gtServer;
+	
+	protected static final int WAITING_TIME_BETWEEN_SERVER_MODE_RETRIES = 1000;
+	protected static final int SERVER_MODE_RETRIES = 60;
 
 	@Override
 	public String getIDString() {
@@ -53,8 +56,15 @@ public abstract class GlobalTesterTest implements InfoSource, Iso7816, Tr03110 {
 		// initialize GT server connection
 		gtServer = new GtServerConnection(GT_SERVER_HOST, GT_SERVER_PORT,
 				GT_SERVER_RESULT_PORT);
-		gtServer.connect();
-
+		
+		int retries = 0;
+		while (!gtServer.connect()){
+			retries++;
+			Thread.sleep(WAITING_TIME_BETWEEN_SERVER_MODE_RETRIES);
+			if (retries > SERVER_MODE_RETRIES){
+				break;
+			}
+		}
 	}
 
 	@AfterClass

--- a/de.persosim.simulator.test/gtTests/de/persosim/simulator/test/globaltester/GtServerConnection.java
+++ b/de.persosim.simulator.test/gtTests/de/persosim/simulator/test/globaltester/GtServerConnection.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import de.persosim.simulator.utils.PersoSimLogger;
+
 /**
  * Encapsulate ServerMode communication with an existing GlobalTester instance
  * in order to include GlobalTester tests within the existing
@@ -184,25 +186,29 @@ public class GtServerConnection {
 	 * Initiate the ServerMode connection to the GlobalTester instance.
 	 * <p/>
 	 * NOTE: the current implementation is not thread safe
-		 
-	 * @throws IOException
 	 */
-	public void connect() throws IOException {
+	public boolean connect() {
 		if (socket != null) {
 			throw new RuntimeException(
 					"GTServerConnection is already connected");
 		}
 
-		socket = new Socket(serverHost, cmdPort);
+		try {
+			socket = new Socket(serverHost, cmdPort);
 
-		if ((socket == null) || (!socket.isConnected())) {
-			throw new RuntimeException(
-					"GTServerConnection: unable to connect to a GT Server ");
+
+			if (!socket.isConnected()) {
+				throw new RuntimeException(
+						"GTServerConnection: unable to connect to a GT Server ");
+			}
+			
+			out = new PrintStream(socket.getOutputStream());
+			in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+			return true;
+		} catch (IOException e) {
+			PersoSimLogger.logException(this.getClass(), e);
+			return false;
 		}
-
-		out = new PrintStream(socket.getOutputStream());
-		in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-		
 	}
 
 	private String transmitCommand(String command) throws IOException {


### PR DESCRIPTION
This implements waiting for the GT server mode to be available to
prevent failed tests caused by connection denied socket errors.